### PR TITLE
avoid nil-pointer dereference in IsOpen

### DIFF
--- a/copyist.go
+++ b/copyist.go
@@ -86,7 +86,7 @@ var registered *proxyDriver
 // testing utility code wants to automatically determine whether to open a
 // connection using the copyist driver or the "real" driver.
 func IsOpen() bool {
-	return registered.recording != nil
+	return registered != nil && registered.recording != nil
 }
 
 // Register constructs a proxy driver that wraps the "real" driver of the given

--- a/copyist_test.go
+++ b/copyist_test.go
@@ -16,15 +16,17 @@ package copyist
 
 import (
 	"database/sql"
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestOpenWithoutRegister tests that copyist.Open panics if copyist.Register
 // was never called.
 func TestOpenWithoutRegister(t *testing.T) {
 	registered = nil
+	require.False(t, IsOpen())
 	require.PanicsWithError(t, "Register was not called", func() {
 		Open(t)
 	})


### PR DESCRIPTION
Avoid a nil-pointer dereference in `IsOpen()` when that function is
called without a copyist driver having been registered.