### PR TITLE
improve findTestFile heuristics

### DIFF
--- a/copyist.go
+++ b/copyist.go
@@ -242,15 +242,19 @@ func OpenNamed(pathName, recordingName string) io.Closer {
 }
 
 // findTestFile searches the call stack, looking for the test that called
-// copyist.Open. It searches up to N levels, looking for a file that ends in
-// "_test.go" and returns that filename.
+// copyist.Open. It searches up to N levels, looking for the last file that
+// ends in "_test.go" and returns that filename.
 func findTestFile() string {
-	const levels = 5
+	const levels = 10
+	var lastTestFilename string
 	for i := 0; i < levels; i++ {
 		_, fileName, _, _ := runtime.Caller(2 + i)
 		if strings.HasSuffix(fileName, "_test.go") {
-			return fileName
+			lastTestFilename = fileName
 		}
+	}
+	if lastTestFilename != "" {
+		return lastTestFilename
 	}
 	panic(fmt.Errorf("Open was not called directly or indirectly from a test file"))
 }

--- a/copyist_test.go
+++ b/copyist_test.go
@@ -17,6 +17,7 @@ package copyist
 import (
 	"database/sql"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -86,6 +87,11 @@ func TestCopyistEnvVar(t *testing.T) {
 	*recordFlag = false
 	visitedRecording = false
 	require.True(t, IsRecording())
+}
+
+// TestFindTestFile tests that copyist finds the top-level *_test.go file.
+func TestFindTestFile(t *testing.T) {
+	require.Equal(t, "copyist_test.go", filepath.Base(indirectFindTestFile()))
 }
 
 func ignorePanic(f func()) {

--- a/indirect_test.go
+++ b/indirect_test.go
@@ -1,0 +1,26 @@
+// Copyright 2020 The Cockroach Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+// implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package copyist
+
+// Indirect calls to findTestFile, used by TestFindTestFile. It is important
+// that these functions are in a different file than TestFindTestFile, and that
+// the call depth is greater than 1.
+func indirectFindTestFile1() string {
+	return findTestFile()
+}
+
+func indirectFindTestFile() string {
+	return indirectFindTestFile1()
+}


### PR DESCRIPTION
`findTestFile` was previously returning the first file in the call stack
that ended in `_test.go`, but that heuristic doesn't work nicely when
there is a `_test.go` file that contains utility functions, such as a
`testServer` struct. The new heuristics is to walk up the call stack
looking for the last file ending in `_test.go`.