### PR TITLE
Fix error extraction during replay in proxyConn.ExecContext

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -104,7 +104,7 @@ func (c *proxyConn) ExecContext(
 	}
 
 	rec := currentSession.VerifyRecordWithStringArg(ConnExec, query)
-	err, _ := rec.Args[0].(error)
+	err, _ := rec.Args[1].(error)
 	if err != nil {
 		return nil, err
 	}

--- a/drivertest/commontest/common.go
+++ b/drivertest/commontest/common.go
@@ -130,6 +130,11 @@ func RunTestQuery(t *testing.T, driverName, dataSourceName string) {
 		require.NoError(t, err)
 	})
 
+	t.Run("exec error", func(t *testing.T) {
+		_, err = db.Exec("SELECT * FROM nonexistent", 1)
+		require.Error(t, err)
+	})
+
 	t.Run("prepare query", func(t *testing.T) {
 		stmt, err := db.Prepare("SELECT name FROM customers WHERE id=$1")
 		require.NoError(t, err)

--- a/drivertest/commontest/testdata/common_test.copyist
+++ b/drivertest/commontest/testdata/common_test.copyist
@@ -1,13 +1,13 @@
 1=DriverOpen	1:nil
-2=ConnQuery	2:"SHOW session_id"	1:nil
-3=RowsColumns	9:["session_id"]
-4=RowsNext	11:[2:"166ef9f90de019430000000000000001"]	1:nil
-5=RowsNext	11:[]	7:EOF
-6=ConnQuery	2:"SELECT name FROM customers WHERE id=$1"	1:nil
-7=RowsColumns	9:["name"]
-8=RowsNext	11:[2:"Andy"]	1:nil
-9=RowsNext	11:[2:"166ef9f91280408f0000000000000001"]	1:nil
+2=ConnQuery	2:"SELECT name FROM customers WHERE id=$1"	1:nil
+3=RowsColumns	9:["name"]
+4=RowsNext	11:[2:"Andy"]	1:nil
+5=ConnQuery	2:"SHOW session_id"	1:nil
+6=RowsColumns	9:["session_id"]
+7=RowsNext	11:[2:"1670ad6136d1f5460000000000000001"]	1:nil
+8=RowsNext	11:[]	7:EOF
+9=RowsNext	11:[2:"1670ad613b4121d80000000000000001"]	1:nil
 
-"TestPooling/ensure_connections_are_pooled_within_same_copyist_session"=1,2,3,4,5,2,3,4,5
-"TestIndirectOpen"=1,6,7,8
-"TestPooling/ensure_connections_are_*not*_pooled_across_copyist_sessions"=1,2,3,9
+"TestIndirectOpen"=1,2,3,4
+"TestPooling/ensure_connections_are_pooled_within_same_copyist_session"=1,5,6,7,8,5,6,7,8
+"TestPooling/ensure_connections_are_*not*_pooled_across_copyist_sessions"=1,5,6,9

--- a/drivertest/pgxtest/testdata/pgxtest_test.copyist
+++ b/drivertest/pgxtest/testdata/pgxtest_test.copyist
@@ -1,38 +1,39 @@
 1=DriverOpen	1:nil
-2=ConnBegin	1:nil
-3=ConnExec	2:"INSERT INTO customers VALUES ($1, $2)"	1:nil
-4=TxCommit	1:nil
-5=TxRollback	1:nil
-6=ConnQuery	2:"SELECT COUNT(*) FROM customers"	1:nil
-7=RowsColumns	9:["count"]
-8=RowsNext	11:[4:4]	1:nil
-9=RowsNext	11:[]	7:EOF
-10=ConnQuery	2:"SELECT name FROM customers WHERE id=$1"	1:nil
-11=RowsColumns	9:["name"]
-12=RowsNext	11:[2:"Andy"]	1:nil
-13=ConnExec	2:"SELECT $1::int"	1:nil
-14=ConnPrepare	2:"SELECT name FROM customers WHERE id=$1"	1:nil
-15=StmtNumInput	3:1
-16=StmtQuery	1:nil
-17=ConnPrepare	2:"SELECT $1::int"	1:nil
-18=StmtExec	1:nil
-19=ResultRowsAffected	4:1	1:nil
-20=ConnExec	2:"\n\t\tCREATE TABLE datatypes\n\t\t(i INT, s TEXT, tz TIMESTAMPTZ, t TIMESTAMP, b BOOL,\n\t\t by BYTES, f FLOAT, d DECIMAL, fa FLOAT[], u UUID)\n\t"	1:nil
-21=ConnExec	2:"\n\t\tINSERT INTO datatypes VALUES\n\t\t\t(1, 'foo' || CHR(9) || CHR(10) || ' ,]', '2000-01-01T10:00:00Z', '2000-01-01T10:00:00Z',\n\t\t\t true, 'ABCD', 1.1, 100.1234, ARRAY(1.1, 1.2345678901234567),\n\t\t\t '8B78978B-7D8B-489E-8CA9-AC4BDC495A82'),\n\t\t\t(2, '', '2000-02-02T11:11:11-08:00', '2000-02-02T11:11:11-08:00', false,\n\t\t\t '', -1e10, -0.0, ARRAY(), '00000000-0000-0000-0000-000000000000')\n\t"	1:nil
-22=ResultRowsAffected	4:0	1:nil
-23=ConnQuery	2:"SELECT i, s, tz, t, b, by, f, d, fa, u FROM datatypes"	1:nil
-24=RowsColumns	9:["i","s","tz","t","b","by","f","d","fa","u"]
-25=RowsNext	11:[4:1,2:"foo\t\n ,]",8:2000-01-01T05:00:00-05:00,8:2000-01-01T10:00:00Z,6:true,10:QUJDRA,5:1.1,2:"100.1234",2:"{1.1,1.2345678901234567}",2:"8b78978b-7d8b-489e-8ca9-ac4bdc495a82"]	1:nil
-26=RowsNext	11:[4:2,2:"",8:2000-02-02T14:11:11-05:00,8:2000-02-02T11:11:11Z,6:false,10:,5:-1e+10,2:"0.0",2:"{}",2:"00000000-0000-0000-0000-000000000000"]	1:nil
-27=ConnQuery	2:"SELECT 1::float, 1.1::float, 1e20::float"	1:nil
-28=RowsColumns	9:["float8","float8","float8"]
-29=RowsNext	11:[5:1,5:1.1,5:1e+20]	1:nil
-30=ConnQuery	2:"SELECT name FROM customers WHERE id=?"	1:nil
+2=ConnQuery	2:"SELECT 1::float, 1.1::float, 1e20::float"	1:nil
+3=RowsColumns	9:["float8","float8","float8"]
+4=RowsNext	11:[5:1,5:1.1,5:1e+20]	1:nil
+5=ConnQuery	2:"SELECT name FROM customers WHERE id=$1"	1:nil
+6=RowsColumns	9:["name"]
+7=RowsNext	11:[2:"Andy"]	1:nil
+8=RowsNext	11:[]	7:EOF
+9=ConnExec	2:"SELECT $1::int"	1:nil
+10=ConnExec	2:"SELECT * FROM nonexistent"	7:ERROR: relation "nonexistent" does not exist (SQLSTATE 42P01)
+11=ConnPrepare	2:"SELECT name FROM customers WHERE id=$1"	1:nil
+12=StmtNumInput	3:1
+13=StmtQuery	1:nil
+14=ConnPrepare	2:"SELECT $1::int"	1:nil
+15=StmtExec	1:nil
+16=ConnExec	2:"INSERT INTO customers VALUES ($1, $2)"	1:nil
+17=ResultRowsAffected	4:1	1:nil
+18=ConnQuery	2:"SELECT COUNT(*) FROM customers"	1:nil
+19=RowsColumns	9:["count"]
+20=RowsNext	11:[4:4]	1:nil
+21=ConnExec	2:"\n\t\tCREATE TABLE datatypes\n\t\t(i INT, s TEXT, tz TIMESTAMPTZ, t TIMESTAMP, b BOOL,\n\t\t by BYTES, f FLOAT, d DECIMAL, fa FLOAT[], u UUID)\n\t"	1:nil
+22=ConnExec	2:"\n\t\tINSERT INTO datatypes VALUES\n\t\t\t(1, 'foo' || CHR(9) || CHR(10) || ' ,]', '2000-01-01T10:00:00Z', '2000-01-01T10:00:00Z',\n\t\t\t true, 'ABCD', 1.1, 100.1234, ARRAY(1.1, 1.2345678901234567),\n\t\t\t '8B78978B-7D8B-489E-8CA9-AC4BDC495A82'),\n\t\t\t(2, '', '2000-02-02T11:11:11-08:00', '2000-02-02T11:11:11-08:00', false,\n\t\t\t '', -1e10, -0.0, ARRAY(), '00000000-0000-0000-0000-000000000000')\n\t"	1:nil
+23=ResultRowsAffected	4:0	1:nil
+24=ConnQuery	2:"SELECT i, s, tz, t, b, by, f, d, fa, u FROM datatypes"	1:nil
+25=RowsColumns	9:["i","s","tz","t","b","by","f","d","fa","u"]
+26=RowsNext	11:[4:1,2:"foo\t\n ,]",8:2000-01-01T05:00:00-05:00,8:2000-01-01T10:00:00Z,6:true,10:QUJDRA,5:1.1,2:"100.1234",2:"{1.1,1.2345678901234567}",2:"8b78978b-7d8b-489e-8ca9-ac4bdc495a82"]	1:nil
+27=RowsNext	11:[4:2,2:"",8:2000-02-02T14:11:11-05:00,8:2000-02-02T11:11:11Z,6:false,10:,5:-1e+10,2:"0.0",2:"{}",2:"00000000-0000-0000-0000-000000000000"]	1:nil
+28=ConnBegin	1:nil
+29=TxCommit	1:nil
+30=TxRollback	1:nil
+31=ConnQuery	2:"SELECT name FROM customers WHERE id=?"	1:nil
 
-"TestFloatLiterals/run_1"=1,27,28,29
-"TestSqlx"=1,2,30,11,12,9,4
-"TestTxns"=1,2,3,4,2,3,5,6,7,8,9
-"TestQuery"=1,10,11,12,9,13,14,14,15,16,11,12,9,17,17,15,18
-"TestInsert"=1,3,19,6,7,8,9
-"TestDataTypes"=1,20,21,22,23,24,25,26
-"TestFloatLiterals/run_2"=1,27,28,29
+"TestFloatLiterals/run_2"=1,2,3,4
+"TestQuery"=1,5,6,7,8,9,10,11,11,12,13,6,7,8,14,14,12,15
+"TestInsert"=1,16,17,18,19,20,8
+"TestDataTypes"=1,21,22,23,24,25,26,27
+"TestTxns"=1,28,16,29,28,16,30,18,19,20,8
+"TestFloatLiterals/run_1"=1,2,3,4
+"TestSqlx"=1,28,31,6,7,8,29

--- a/drivertest/pqtest/testdata/pqtest_test.copyist
+++ b/drivertest/pqtest/testdata/pqtest_test.copyist
@@ -1,43 +1,44 @@
 1=DriverOpen	1:nil
-2=ConnExec	2:"INSERT INTO customers VALUES ($1, $2)"	1:nil
-3=ResultRowsAffected	4:1	1:nil
-4=ConnQuery	2:"SELECT COUNT(*) FROM customers"	1:nil
-5=RowsColumns	9:["count"]
-6=RowsNext	11:[4:4]	1:nil
-7=RowsNext	11:[]	7:EOF
-8=ConnQuery	2:"SELECT 1::float, 1.1::float, 1e20::float"	1:nil
-9=RowsColumns	9:["float8","float8","float8"]
-10=RowsNext	11:[5:1,5:1.1,5:1e+20]	1:nil
-11=ConnBegin	1:nil
-12=TxCommit	1:nil
-13=TxRollback	1:nil
-14=ConnExec	2:"\n\t\tCREATE TABLE datatypes\n\t\t(i INT, s TEXT, tz TIMESTAMPTZ, t TIMESTAMP, b BOOL,\n\t\t by BYTES, f FLOAT, d DECIMAL, fa FLOAT[], u UUID)\n\t"	1:nil
-15=ConnExec	2:"\n\t\tINSERT INTO datatypes VALUES\n\t\t\t(1, 'foo' || CHR(9) || CHR(10) || ' ,]', '2000-01-01T10:00:00Z', '2000-01-01T10:00:00Z',\n\t\t\t true, 'ABCD', 1.1, 100.1234, ARRAY(1.1, 1.2345678901234567),\n\t\t\t '8B78978B-7D8B-489E-8CA9-AC4BDC495A82'),\n\t\t\t(2, '', '2000-02-02T11:11:11-08:00', '2000-02-02T11:11:11-08:00', false,\n\t\t\t '', -1e10, -0.0, ARRAY(), '00000000-0000-0000-0000-000000000000')\n\t"	1:nil
-16=ResultRowsAffected	4:0	1:nil
-17=ConnQuery	2:"SELECT i, s, tz, t, b, by, f, d, fa, u FROM datatypes"	1:nil
-18=RowsColumns	9:["i","s","tz","t","b","by","f","d","fa","u"]
-19=RowsNext	11:[4:1,2:"foo\t\n ,]",8:2000-01-01T10:00:00Z,8:2000-01-01T10:00:00+00:00,6:true,10:QUJDRA,5:1.1,10:MTAwLjEyMzQ,10:ezEuMSwxLjIzNDU2Nzg5MDEyMzQ1Njd9,10:OGI3ODk3OGItN2Q4Yi00ODllLThjYTktYWM0YmRjNDk1YTgy]	1:nil
-20=RowsNext	11:[4:2,2:"",8:2000-02-02T19:11:11Z,8:2000-02-02T11:11:11+00:00,6:false,10:,5:-1e+10,10:MC4w,10:e30,10:MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAw]	1:nil
-21=ConnQuery	2:"SELECT name FROM customers WHERE id=$1"	1:nil
-22=RowsColumns	9:["name"]
-23=RowsNext	11:[2:"Andy"]	1:nil
-24=ConnExec	2:"SELECT $1::int"	1:nil
-25=ConnPrepare	2:"SELECT name FROM customers WHERE id=$1"	1:nil
-26=StmtNumInput	3:1
-27=StmtQuery	1:nil
-28=ConnPrepare	2:"SELECT $1::int"	1:nil
-29=StmtExec	1:nil
-30=ConnExec	2:"SELECT 1; SELECT 2;"	1:nil
-31=ConnQuery	2:"SELECT 1; SELECT 2;"	1:nil
-32=RowsColumns	9:["?column?"]
-33=RowsNext	11:[4:1]	1:nil
-34=ConnQuery	2:"SELECT name FROM customers WHERE id=?"	1:nil
+2=ConnQuery	2:"SELECT 1::float, 1.1::float, 1e20::float"	1:nil
+3=RowsColumns	9:["float8","float8","float8"]
+4=RowsNext	11:[5:1,5:1.1,5:1e+20]	1:nil
+5=ConnExec	2:"SELECT 1; SELECT 2;"	1:nil
+6=ConnQuery	2:"SELECT 1; SELECT 2;"	1:nil
+7=RowsColumns	9:["?column?"]
+8=RowsNext	11:[4:1]	1:nil
+9=RowsNext	11:[]	7:EOF
+10=ConnExec	2:"INSERT INTO customers VALUES ($1, $2)"	1:nil
+11=ResultRowsAffected	4:1	1:nil
+12=ConnQuery	2:"SELECT COUNT(*) FROM customers"	1:nil
+13=RowsColumns	9:["count"]
+14=RowsNext	11:[4:4]	1:nil
+15=ConnExec	2:"\n\t\tCREATE TABLE datatypes\n\t\t(i INT, s TEXT, tz TIMESTAMPTZ, t TIMESTAMP, b BOOL,\n\t\t by BYTES, f FLOAT, d DECIMAL, fa FLOAT[], u UUID)\n\t"	1:nil
+16=ConnExec	2:"\n\t\tINSERT INTO datatypes VALUES\n\t\t\t(1, 'foo' || CHR(9) || CHR(10) || ' ,]', '2000-01-01T10:00:00Z', '2000-01-01T10:00:00Z',\n\t\t\t true, 'ABCD', 1.1, 100.1234, ARRAY(1.1, 1.2345678901234567),\n\t\t\t '8B78978B-7D8B-489E-8CA9-AC4BDC495A82'),\n\t\t\t(2, '', '2000-02-02T11:11:11-08:00', '2000-02-02T11:11:11-08:00', false,\n\t\t\t '', -1e10, -0.0, ARRAY(), '00000000-0000-0000-0000-000000000000')\n\t"	1:nil
+17=ResultRowsAffected	4:0	1:nil
+18=ConnQuery	2:"SELECT i, s, tz, t, b, by, f, d, fa, u FROM datatypes"	1:nil
+19=RowsColumns	9:["i","s","tz","t","b","by","f","d","fa","u"]
+20=RowsNext	11:[4:1,2:"foo\t\n ,]",8:2000-01-01T10:00:00Z,8:2000-01-01T10:00:00+00:00,6:true,10:QUJDRA,5:1.1,10:MTAwLjEyMzQ,10:ezEuMSwxLjIzNDU2Nzg5MDEyMzQ1Njd9,10:OGI3ODk3OGItN2Q4Yi00ODllLThjYTktYWM0YmRjNDk1YTgy]	1:nil
+21=RowsNext	11:[4:2,2:"",8:2000-02-02T19:11:11Z,8:2000-02-02T11:11:11+00:00,6:false,10:,5:-1e+10,10:MC4w,10:e30,10:MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAw]	1:nil
+22=ConnBegin	1:nil
+23=TxCommit	1:nil
+24=TxRollback	1:nil
+25=ConnQuery	2:"SELECT name FROM customers WHERE id=$1"	1:nil
+26=RowsColumns	9:["name"]
+27=RowsNext	11:[2:"Andy"]	1:nil
+28=ConnExec	2:"SELECT $1::int"	1:nil
+29=ConnExec	2:"SELECT * FROM nonexistent"	7:pq: relation "nonexistent" does not exist
+30=ConnPrepare	2:"SELECT name FROM customers WHERE id=$1"	1:nil
+31=StmtNumInput	3:1
+32=StmtQuery	1:nil
+33=ConnPrepare	2:"SELECT $1::int"	1:nil
+34=StmtExec	1:nil
+35=ConnQuery	2:"SELECT name FROM customers WHERE id=?"	1:nil
 
-"TestFloatLiterals/run_2"=1,8,9,10
-"TestTxns"=1,11,2,12,11,2,13,4,5,6,7
-"TestDataTypes"=1,14,15,16,17,18,19,20
-"TestQuery"=1,21,22,23,7,24,25,25,26,27,22,23,7,28,28,26,29
-"TestFloatLiterals/run_1"=1,8,9,10
-"TestMultiStatement"=1,30,31,32,33,7
-"TestSqlx"=1,11,34,22,23,7,12
-"TestInsert"=1,2,3,4,5,6,7
+"TestSqlx"=1,22,35,26,27,9,23
+"TestFloatLiterals/run_1"=1,2,3,4
+"TestMultiStatement"=1,5,6,7,8,9
+"TestInsert"=1,10,11,12,13,14,9
+"TestFloatLiterals/run_2"=1,2,3,4
+"TestDataTypes"=1,15,16,17,18,19,20,21
+"TestTxns"=1,22,10,23,22,10,24,12,13,14,9
+"TestQuery"=1,25,26,27,9,28,29,30,30,31,32,26,27,9,33,33,31,34

--- a/drivertest/pqtestold/testdata/pqtestold_test.copyist
+++ b/drivertest/pqtestold/testdata/pqtestold_test.copyist
@@ -1,44 +1,45 @@
 1=DriverOpen	1:nil
-2=ConnExec	2:"INSERT INTO customers VALUES ($1, $2)"	1:nil
-3=ResultRowsAffected	4:1	1:nil
-4=ConnQuery	2:"SELECT COUNT(*) FROM customers"	1:nil
-5=RowsColumns	9:["count"]
-6=RowsNext	11:[4:4]	1:nil
-7=RowsNext	11:[]	7:EOF
-8=ConnBegin	1:nil
-9=TxCommit	1:nil
-10=TxRollback	1:nil
-11=ConnQuery	2:"SELECT name FROM customers WHERE id=$1"	1:nil
-12=RowsColumns	9:["name"]
-13=RowsNext	11:[2:"Andy"]	1:nil
-14=ConnExec	2:"SELECT $1::int"	1:nil
-15=ConnPrepare	2:"SELECT name FROM customers WHERE id=$1"	1:nil
-16=StmtNumInput	3:1
-17=StmtQuery	1:nil
-18=ConnPrepare	2:"SELECT $1::int"	1:nil
-19=StmtExec	1:nil
-20=ConnExec	2:"SELECT 1; SELECT 2;"	1:nil
-21=ConnQuery	2:"SELECT 1; SELECT 2;"	1:nil
-22=RowsColumns	9:["?column?"]
-23=RowsNext	11:[4:1]	1:nil
-24=RowsNext	11:[]	7:pq: unexpected message after execute: 'T'
-25=ConnExec	2:"\n\t\tCREATE TABLE datatypes\n\t\t(i INT, s TEXT, tz TIMESTAMPTZ, t TIMESTAMP, b BOOL,\n\t\t by BYTES, f FLOAT, d DECIMAL, fa FLOAT[], u UUID)\n\t"	1:nil
-26=ConnExec	2:"\n\t\tINSERT INTO datatypes VALUES\n\t\t\t(1, 'foo' || CHR(9) || CHR(10) || ' ,]', '2000-01-01T10:00:00Z', '2000-01-01T10:00:00Z',\n\t\t\t true, 'ABCD', 1.1, 100.1234, ARRAY(1.1, 1.2345678901234567),\n\t\t\t '8B78978B-7D8B-489E-8CA9-AC4BDC495A82'),\n\t\t\t(2, '', '2000-02-02T11:11:11-08:00', '2000-02-02T11:11:11-08:00', false,\n\t\t\t '', -1e10, -0.0, ARRAY(), '00000000-0000-0000-0000-000000000000')\n\t"	1:nil
-27=ResultRowsAffected	4:0	1:nil
-28=ConnQuery	2:"SELECT i, s, tz, t, b, by, f, d, fa, u FROM datatypes"	1:nil
-29=RowsColumns	9:["i","s","tz","t","b","by","f","d","fa","u"]
-30=RowsNext	11:[4:1,2:"foo\t\n ,]",8:2000-01-01T10:00:00Z,8:2000-01-01T10:00:00+00:00,6:true,10:QUJDRA,5:1.1,10:MTAwLjEyMzQ,10:ezEuMSwxLjIzNDU2Nzg5MDEyMzQ1Njd9,10:OGI3ODk3OGItN2Q4Yi00ODllLThjYTktYWM0YmRjNDk1YTgy]	1:nil
-31=RowsNext	11:[4:2,2:"",8:2000-02-02T19:11:11Z,8:2000-02-02T11:11:11+00:00,6:false,10:,5:-1e+10,10:MC4w,10:e30,10:MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAw]	1:nil
-32=ConnQuery	2:"SELECT 1::float, 1.1::float, 1e20::float"	1:nil
-33=RowsColumns	9:["float8","float8","float8"]
-34=RowsNext	11:[5:1,5:1.1,5:1e+20]	1:nil
-35=ConnQuery	2:"SELECT name FROM customers WHERE id=?"	1:nil
+2=ConnExec	2:"\n\t\tCREATE TABLE datatypes\n\t\t(i INT, s TEXT, tz TIMESTAMPTZ, t TIMESTAMP, b BOOL,\n\t\t by BYTES, f FLOAT, d DECIMAL, fa FLOAT[], u UUID)\n\t"	1:nil
+3=ConnExec	2:"\n\t\tINSERT INTO datatypes VALUES\n\t\t\t(1, 'foo' || CHR(9) || CHR(10) || ' ,]', '2000-01-01T10:00:00Z', '2000-01-01T10:00:00Z',\n\t\t\t true, 'ABCD', 1.1, 100.1234, ARRAY(1.1, 1.2345678901234567),\n\t\t\t '8B78978B-7D8B-489E-8CA9-AC4BDC495A82'),\n\t\t\t(2, '', '2000-02-02T11:11:11-08:00', '2000-02-02T11:11:11-08:00', false,\n\t\t\t '', -1e10, -0.0, ARRAY(), '00000000-0000-0000-0000-000000000000')\n\t"	1:nil
+4=ResultRowsAffected	4:0	1:nil
+5=ConnQuery	2:"SELECT i, s, tz, t, b, by, f, d, fa, u FROM datatypes"	1:nil
+6=RowsColumns	9:["i","s","tz","t","b","by","f","d","fa","u"]
+7=RowsNext	11:[4:1,2:"foo\t\n ,]",8:2000-01-01T10:00:00Z,8:2000-01-01T10:00:00+00:00,6:true,10:QUJDRA,5:1.1,10:MTAwLjEyMzQ,10:ezEuMSwxLjIzNDU2Nzg5MDEyMzQ1Njd9,10:OGI3ODk3OGItN2Q4Yi00ODllLThjYTktYWM0YmRjNDk1YTgy]	1:nil
+8=RowsNext	11:[4:2,2:"",8:2000-02-02T19:11:11Z,8:2000-02-02T11:11:11+00:00,6:false,10:,5:-1e+10,10:MC4w,10:e30,10:MDAwMDAwMDAtMDAwMC0wMDAwLTAwMDAtMDAwMDAwMDAwMDAw]	1:nil
+9=ConnQuery	2:"SELECT 1::float, 1.1::float, 1e20::float"	1:nil
+10=RowsColumns	9:["float8","float8","float8"]
+11=RowsNext	11:[5:1,5:1.1,5:1e+20]	1:nil
+12=ConnQuery	2:"SELECT name FROM customers WHERE id=$1"	1:nil
+13=RowsColumns	9:["name"]
+14=RowsNext	11:[2:"Andy"]	1:nil
+15=RowsNext	11:[]	7:EOF
+16=ConnExec	2:"SELECT $1::int"	1:nil
+17=ConnExec	2:"SELECT * FROM nonexistent"	7:pq: relation "nonexistent" does not exist
+18=ConnPrepare	2:"SELECT name FROM customers WHERE id=$1"	1:nil
+19=StmtNumInput	3:1
+20=StmtQuery	1:nil
+21=ConnPrepare	2:"SELECT $1::int"	1:nil
+22=StmtExec	1:nil
+23=ConnBegin	1:nil
+24=ConnExec	2:"INSERT INTO customers VALUES ($1, $2)"	1:nil
+25=TxCommit	1:nil
+26=TxRollback	1:nil
+27=ConnQuery	2:"SELECT COUNT(*) FROM customers"	1:nil
+28=RowsColumns	9:["count"]
+29=RowsNext	11:[4:4]	1:nil
+30=ResultRowsAffected	4:1	1:nil
+31=ConnExec	2:"SELECT 1; SELECT 2;"	1:nil
+32=ConnQuery	2:"SELECT 1; SELECT 2;"	1:nil
+33=RowsColumns	9:["?column?"]
+34=RowsNext	11:[4:1]	1:nil
+35=RowsNext	11:[]	7:pq: unexpected message after execute: 'T'
+36=ConnQuery	2:"SELECT name FROM customers WHERE id=?"	1:nil
 
-"TestSqlx"=1,8,35,12,13,7,9
-"TestInsert"=1,2,3,4,5,6,7
-"TestTxns"=1,8,2,9,8,2,10,4,5,6,7
-"TestQuery"=1,11,12,13,7,14,15,15,16,17,12,13,7,18,18,16,19
-"TestMultiStatement"=1,20,21,22,23,24
-"TestDataTypes"=1,25,26,27,28,29,30,31
-"TestFloatLiterals/run_1"=1,32,33,34
-"TestFloatLiterals/run_2"=1,32,33,34
+"TestQuery"=1,12,13,14,15,16,17,18,18,19,20,13,14,15,21,21,19,22
+"TestTxns"=1,23,24,25,23,24,26,27,28,29,15
+"TestInsert"=1,24,30,27,28,29,15
+"TestMultiStatement"=1,31,32,33,34,35
+"TestSqlx"=1,23,36,13,14,15,25
+"TestDataTypes"=1,2,3,4,5,6,7,8
+"TestFloatLiterals/run_1"=1,9,10,11
+"TestFloatLiterals/run_2"=1,9,10,11


### PR DESCRIPTION
We were using the wrong argument index for the error, causing an error
to never be replayed correctly in `ExecContext`.