### PR TITLE
pass through non-session panics, rather than swallowing them

### DIFF
--- a/copyist.go
+++ b/copyist.go
@@ -197,6 +197,8 @@ func OpenNamed(t testingT, pathName, recordingName string) io.Closer {
 		// Convert sessionError panics into fatal test errors.
 		if _, ok := r.(*sessionError); ok {
 			t.Fatalf("%v\n", r)
+		} else if r != nil {
+			panic(r)
 		}
 
 		currentSession.Close()

--- a/copyist_test.go
+++ b/copyist_test.go
@@ -115,6 +115,23 @@ func TestSessionPanicsAreCaught(t *testing.T) {
 	db.Query("SELECT 1")
 }
 
+func TestNonSessionPanicsAreNotCaught(t *testing.T) {
+	// Enter playback mode.
+	*recordFlag = false
+	visitedRecording = true
+
+	registered = nil
+	Register("postgres2")
+
+	defer func() {
+		require.Equal(t, recover(), "test panic")
+	}()
+
+	defer Open(t).Close()
+
+	panic("test panic")
+}
+
 // TestCopyistEnvVar tests that copyist respects the COPYIST_RECORD environment
 // variable.
 func TestCopyistEnvVar(t *testing.T) {

--- a/recording_file.go
+++ b/recording_file.go
@@ -139,7 +139,7 @@ func (f *recordingFile) WriteRecordingFile() {
 	// given record declaration.
 	addRecordDecl := func(recordDecl string) int {
 		if len(recordDecl) > MaxRecordingSize {
-			panic(errors.New("recording exceeds copyist.MaxRecordingSize and cannot be written"))
+			panicf("recording exceeds copyist.MaxRecordingSize and cannot be written")
 		}
 
 		hashVal := f.hashStr(recordDecl)
@@ -180,7 +180,7 @@ func (f *recordingFile) WriteRecordingFile() {
 		for i, num := range oldRecordNums {
 			recordDecl, ok := f.recordDecls[num]
 			if !ok {
-				panic(fmt.Errorf("record with number %d must exist", num))
+				panicf("record with number %d must exist", num)
 			}
 			newRecordNums[i] = addRecordDecl(recordDecl)
 		}
@@ -221,13 +221,13 @@ func (f *recordingFile) WriteRecordingFile() {
 	dirName := path.Dir(f.pathName)
 	if _, err := os.Stat(dirName); os.IsNotExist(err) {
 		if err := os.MkdirAll(dirName, 0777); err != nil {
-			panic(err)
+			panicf("%+v", err)
 		}
 	}
 
 	// Write the bytes to disk.
 	if err := ioutil.WriteFile(f.pathName, f.scratch.Bytes(), 0666); err != nil {
-		panic(err)
+		panicf("%+v", err)
 	}
 }
 
@@ -302,7 +302,7 @@ func (f *recordingFile) parseRecordingDecl(decl string) []int {
 	for i := range numStrs {
 		num, err := strconv.Atoi(numStrs[i])
 		if err != nil {
-			panic(err)
+			panicf("%+v", err)
 		}
 
 		// Convert from 1-based record number to 0-based number.
@@ -330,7 +330,7 @@ func (f *recordingFile) formatRecord(record *record) string {
 func (f *recordingFile) parseRecord(recordNum int) *record {
 	r, ok := f.recordDecls[recordNum]
 	if !ok {
-		panic(fmt.Errorf("record with number %d must exist", recordNum))
+		panicf("record with number %d must exist", recordNum)
 	}
 
 	// Record fields are separated by tabs, with the first field being the name
@@ -338,7 +338,7 @@ func (f *recordingFile) parseRecord(recordNum int) *record {
 	fields := splitString(r, "\t")
 	recType, ok := strToRecType[fields[0]]
 	if !ok {
-		panic(fmt.Errorf("record type %v is not recognized", fields[0]))
+		panicf("record type %v is not recognized", fields[0])
 	}
 
 	// Remaining fields are record arguments in "<dataType>:<formattedValue>"
@@ -347,7 +347,7 @@ func (f *recordingFile) parseRecord(recordNum int) *record {
 	for i := 1; i < len(fields); i++ {
 		val, err := parseValueWithType(fields[i])
 		if err != nil {
-			panic(fmt.Errorf("error parsing %s: %v", fields[i], err))
+			panicf("error parsing %s: %v", fields[i], err)
 		}
 		rec.Args = append(rec.Args, val)
 	}

--- a/session.go
+++ b/session.go
@@ -86,14 +86,14 @@ func (s *session) OnDriverOpen(driver *proxyDriver) {
 		// Need to play back a recording file, so parse it now.
 		if _, err := os.Stat(s.file.pathName); !os.IsNotExist(err) {
 			if err = s.file.Parse(); err != nil {
-				s.panicf("error parsing recording file: %v", err)
+				panicf("error parsing recording file: %v", err)
 			}
 		}
 
 		// Set the list of records to play back for the current session.
 		s.recording = s.file.GetRecording(s.recordingName)
 		if s.recording == nil {
-			s.panicf("no recording exists with this name: %v", s.recordingName)
+			panicf("no recording exists with this name: %v", s.recordingName)
 		}
 	}
 
@@ -113,7 +113,7 @@ func (s *session) AddRecord(rec *record) {
 func (s *session) VerifyRecordWithStringArg(recordTyp recordType, arg string) *record {
 	rec := s.VerifyRecord(recordTyp)
 	if rec.Args[0].(string) != arg {
-		s.panicf(
+		panicf(
 			"mismatched argument to %s, expected %s, got %s\n\n"+
 				"Do you need to regenerate the recording with the -record flag?",
 			recordTyp.String(), arg, rec.Args[0].(string))
@@ -125,13 +125,13 @@ func (s *session) VerifyRecordWithStringArg(recordTyp recordType, arg string) *r
 // with a nice error if no such record exists.
 func (s *session) VerifyRecord(recordTyp recordType) *record {
 	if s.index >= len(s.recording) {
-		s.panicf(
+		panicf(
 			"too many calls to %s\n\n"+
 				"Do you need to regenerate the recording with the -record flag?", recordTyp.String())
 	}
 	rec := s.recording[s.index]
 	if rec.Typ != recordTyp {
-		s.panicf(
+		panicf(
 			"unexpected call to %s\n\n"+
 				"Do you need to regenerate the recording with the -record flag?", recordTyp.String())
 	}
@@ -160,7 +160,7 @@ func (s *session) Close() {
 	clearPooledConnections()
 }
 
-func (s *session) panicf(format string, args ...interface{}) {
+func panicf(format string, args ...interface{}) {
 	panic(&sessionError{fmt.Errorf(format, args...)})
 }
 


### PR DESCRIPTION
The previous commit to translate session panics into `testing.T.Fatal`
errors unintentionally caused non-session panics in the test to be
swallowed.

Convert the `recordingFile` panics into `sessionError` so they can be
translated to `testing.T.Fatal`.