### PR TITLE
Add support for non-file recordings

### DIFF
--- a/copyist.go
+++ b/copyist.go
@@ -186,11 +186,25 @@ func Open(t testingT) io.Closer {
 // file rather than using the testing.T.Name() value.
 func OpenNamed(t testingT, pathName, recordingName string) io.Closer {
 	if registered == nil {
-		panic("Register was not called")
+		panic(errors.New("Register was not called"))
+	}
+
+	return OpenSource(t, fileSource{PathName: pathName}, recordingName)
+}
+
+// OpenSource is a variant of Open which accepts a caller-specified source and
+// recordingName rather than deriving default values for them. The given source
+// will be used to persist and load recordings rather than the default
+// "_test.copyist" file in the testdata directory. The given recordingName will
+// be used as the recording name in that file rather than using the
+// testing.T.Name() value.
+func OpenSource(t testingT, source Source, recordingName string) io.Closer {
+	if registered == nil {
+		panic(errors.New("Register was not called"))
 	}
 
 	// Start a new recording or playback session.
-	currentSession = newSession(pathName, recordingName)
+	currentSession = newSession(source, recordingName)
 
 	// Return a closer that will close the session when called.
 	return closer(func(r interface{}) error {

--- a/copyist_test.go
+++ b/copyist_test.go
@@ -100,7 +100,7 @@ func TestSessionPanicsAreCaught(t *testing.T) {
 	registered = nil
 	Register("postgres2")
 
-	m := &mockTestingT{T:t}
+	m := &mockTestingT{T: t}
 	defer func() {
 		require.Equal(t, "no recording exists with this name: TestSessionPanicsAreCaught\n",
 			m.buf.String())

--- a/copyist_test.go
+++ b/copyist_test.go
@@ -121,7 +121,7 @@ func TestNonSessionPanicsAreNotCaught(t *testing.T) {
 	visitedRecording = true
 
 	registered = nil
-	Register("postgres2")
+	Register("postgres3")
 
 	defer func() {
 		require.Equal(t, recover(), "test panic")


### PR DESCRIPTION
     Add support for non-file recordings

        This commit exposes copyist.OpenSource as an alternative to
        copyist.OpenNamed. OpenSource allows users to pass an
        io.ReadWriteCloser which allows them to control how a recording is
        loaded and persisted. For example, if users wish to handle a common
        query executed open opening a connection, like a version check, it
        may be inconvenient to locate a common recording file. OpenSource
        would allow users to go:embed the common recording in a shared
        package rather than struggling with locating a file from many
        packages.

This PR also contains a fix for `TestNonSessionPanicsAreNotCaught`
