### PR TITLE
fix panic message in VerifyRecordWithStringArg

### DIFF
--- a/session.go
+++ b/session.go
@@ -113,7 +113,7 @@ func (s *session) VerifyRecordWithStringArg(recordTyp recordType, arg string) *r
 		panicf(
 			"mismatched argument to %s, expected %s, got %s\n\n"+
 				"Do you need to regenerate the recording with the -record flag?",
-			recordTyp.String(), arg, rec.Args[0].(string))
+			recordTyp.String(), rec.Args[0].(string), arg)
 	}
 	return rec
 }


### PR DESCRIPTION
It appears that the "mismatched arugment" panic message prints the
"expected" and "got" queries mixed around, this change fixes that.