### PR TITLE
Support for drivers without ConnExec & ConnQuery

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -74,6 +74,10 @@ func (c *proxyConn) ResetSession(ctx context.Context) error {
 func (c *proxyConn) ExecContext(
 	ctx context.Context, query string, args []driver.NamedValue,
 ) (driver.Result, error) {
+	if IsConnExecDisabled() {
+		fmt.Println("The use of ConnExec is disabled. Returning driver.ErrSkip to allow driver to fallback to other methods (ConnPrepare).")
+		return nil, driver.ErrSkip
+	}
 	if IsRecording() {
 		var res driver.Result
 		var err error

--- a/conn.go
+++ b/conn.go
@@ -17,7 +17,6 @@ package copyist
 import (
 	"context"
 	"database/sql/driver"
-	"fmt"
 )
 
 // proxyConn records and plays back calls to driver.Conn methods.
@@ -75,7 +74,6 @@ func (c *proxyConn) ExecContext(
 	ctx context.Context, query string, args []driver.NamedValue,
 ) (driver.Result, error) {
 	if IsConnExecDisabled() {
-		fmt.Println("The use of ConnExec is disabled. Returning driver.ErrSkip to allow driver to fallback to other methods (ConnPrepare).")
 		return nil, driver.ErrSkip
 	}
 	if IsRecording() {
@@ -157,7 +155,6 @@ func (c *proxyConn) QueryContext(
 	ctx context.Context, query string, args []driver.NamedValue,
 ) (driver.Rows, error) {
 	if IsConnQueryDisabled() {
-		fmt.Println("The use of ConnQuery is disabled. Returning driver.ErrSkip to allow driver to fallback to other methods (ConnPrepare).")
 		return nil, driver.ErrSkip
 	}
 	if IsRecording() {

--- a/conn.go
+++ b/conn.go
@@ -17,6 +17,7 @@ package copyist
 import (
 	"context"
 	"database/sql/driver"
+	"fmt"
 )
 
 // proxyConn records and plays back calls to driver.Conn methods.
@@ -151,6 +152,10 @@ func (c *proxyConn) PrepareContext(ctx context.Context, query string) (driver.St
 func (c *proxyConn) QueryContext(
 	ctx context.Context, query string, args []driver.NamedValue,
 ) (driver.Rows, error) {
+	if IsConnQueryDisabled() {
+		fmt.Println("The use of ConnQuery is disabled. Returning driver.ErrSkip to allow driver to fallback to other methods (ConnPrepare).")
+		return nil, driver.ErrSkip
+	}
 	if IsRecording() {
 		var rows driver.Rows
 		var err error

--- a/copyist.go
+++ b/copyist.go
@@ -41,6 +41,10 @@ var recordFlag = flag.Bool("record", true, "record sql database accesses")
 
 var visitedRecording bool
 
+// disableConnQueryFlag instructs copyist to disable the use of ConnQuery, if true. This is useful when using copyist with
+// drivers that do not support ConnQuery (and fallback to ConnPrepare). One such case is `sqlserver` and `azuresql`.
+var disableConnQueryFlag = flag.Bool("disable-conn-query", false, "disable the usage of ConnQuery")
+
 // IsRecording returns true if copyist is currently in recording mode.
 func IsRecording() bool {
 	// Determine whether the "record" flag was explicitly passed rather than
@@ -64,6 +68,11 @@ func IsRecording() bool {
 		visitedRecording = true
 	}
 	return *recordFlag
+}
+
+// IsConnQueryDisabled returns true if usage of ConnQuery is disabled.
+func IsConnQueryDisabled() bool {
+	return *disableConnQueryFlag
 }
 
 // MaxRecordingSize is the maximum size, in bytes, of a single recording in its

--- a/copyist.go
+++ b/copyist.go
@@ -45,13 +45,13 @@ var visitedRecording bool
 // drivers that do not support ConnQuery (and fallback to ConnPrepare). One such case is `sqlserver` and `azuresql`.
 var disableConnQueryFlag = flag.Bool("disable-conn-query", false, "disable the usage of ConnQuery")
 
-var visitedDisableConnQueryFlag bool
+var hasSetDisableConnQueryFlag bool
 
 // disableConnExecFlag instructs copyist to disable the use of ConnExec, if true. This is useful when using copyist with
 // drivers that do not support ConnExec (and fallback to ConnPrepare).
 var disableConnExecFlag = flag.Bool("disable-conn-exec", false, "disable the usage of ConnExec")
 
-var visitedDisableConnExecFlag bool
+var hasSetDisableConnExecFlag bool
 
 // IsRecording returns true if copyist is currently in recording mode.
 func IsRecording() bool {
@@ -78,11 +78,16 @@ func IsRecording() bool {
 	return *recordFlag
 }
 
+func DisableConnQuery() {
+	*disableConnQueryFlag = true
+	hasSetDisableConnQueryFlag = true
+}
+
 // IsConnQueryDisabled returns true if usage of ConnQuery is disabled.
 func IsConnQueryDisabled() bool {
 	// Determine whether the "disable-conn-query" flag was explicitly passed rather than
 	// defaulted. This is painful and slow in Go, so do it just once.
-	if !visitedDisableConnQueryFlag {
+	if !hasSetDisableConnQueryFlag {
 		found := false
 		flag.Visit(func(f *flag.Flag) {
 			if f.Name == "disable-conn-query" {
@@ -98,16 +103,21 @@ func IsConnQueryDisabled() bool {
 				*disableConnQueryFlag = false
 			}
 		}
-		visitedDisableConnQueryFlag = true
+		hasSetDisableConnQueryFlag = true
 	}
 	return *disableConnQueryFlag
+}
+
+func DisableConnExec() {
+	*disableConnExecFlag = true
+	hasSetDisableConnExecFlag = true
 }
 
 // IsConnExecDisabled returns true if usage of ConnExec is disabled.
 func IsConnExecDisabled() bool {
 	// Determine whether the "disable-conn-exec" flag was explicitly passed rather than
 	// defaulted. This is painful and slow in Go, so do it just once.
-	if !visitedDisableConnExecFlag {
+	if !hasSetDisableConnExecFlag {
 		found := false
 		flag.Visit(func(f *flag.Flag) {
 			if f.Name == "disable-conn-exec" {
@@ -123,7 +133,7 @@ func IsConnExecDisabled() bool {
 				*disableConnExecFlag = false
 			}
 		}
-		visitedDisableConnExecFlag = true
+		hasSetDisableConnExecFlag = true
 	}
 	return *disableConnExecFlag
 }


### PR DESCRIPTION
This appears to make copyist work for my mysql usecase (golang & gorm)

Related to and expansion on https://github.com/cockroachdb/copyist/issues/25

At setup time I have

```
		copyist.Register("mysql") // Register the custom driver for test
		copyist.DisableConnExec()
		copyist.DisableConnQuery()
```